### PR TITLE
Support for using gpg keys to provide passwords

### DIFF
--- a/lib/m_printer
+++ b/lib/m_printer
@@ -114,7 +114,10 @@ print_imap()
         print_commented_auto_warning
         echo
         local imap_order=${settings[general.imap_order]-${!accounts[@]}}
+        local lib_folder=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
         printf '[general]\n'
+        printf "pythonfile = $lib_folder/python_file.py\n"
+
         local k
         for k in $(keys | grep '^general\.imap\.'); do
             [[ "$k" =~ ^general\.imap\.(.*)$ ]]

--- a/lib/python_file.py
+++ b/lib/python_file.py
@@ -1,0 +1,26 @@
+#! /usr/bin/env python2
+# Do not modify this file. Place any custom python functions in a file called 
+# userPython.py in ~/.offlineimap/ and it will be imported. The functions defined 
+# in that file can be accessed in the 'userDefined' namespace.
+# Ex. "~/.offlineimap/userPython.py":
+#     def testing():
+#         print ("test")
+# Can be used called in .muttererrc as:
+#     userDefined.testing()
+
+import os
+import subprocess
+import imp
+
+def mailpasswd(accountName):
+    keysDirectory = os.path.expanduser("~/.offlineimap/keys/");
+    path = keysDirectory + accountName + ".asc"
+    args = ["gpg", "--use-agent", "--quiet", "--batch", "-d", path]
+    try:
+        return subprocess.check_output(args).strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+userPythonPath = os.path.expanduser("~/.offlineimap/userPython.py");
+if os.path.exists(userPythonPath):
+    userDefined = imp.load_source('module.name', userPythonPath)

--- a/presets/defaults
+++ b/presets/defaults
@@ -147,5 +147,5 @@ smtp.tls_trust_file  ?~= "$(\
        "%{smtp.tls_certcheck:-}" == off ]] \
     || echo /etc/ssl/certs/ca-certificates.crt)"
 smtp.logfile          ?= ~/.msmtp/%{id}.log
-smtp.passwordeval     ?~= $(printn "gpg2 -q --for-your-eyes-only --no-tty -d ~/.keys/%{id}.asc")
+smtp.passwordeval     ?~= $(printn "gpg2 -q --for-your-eyes-only --no-tty -d ~/.offlineimap/keys/%{id}.asc")
 # smtp.maildomain ?= 

--- a/presets/defaults
+++ b/presets/defaults
@@ -132,6 +132,7 @@ imap.Repository remote_%{id}.remoteport ?~= $([[ ! "%{imap_host}" =~ : ]] || ech
 imap.Repository remote_%{id}.ssl        ?~= %{imap_ssl:-}
 imap.Repository remote_%{id}.remotepass  ?= %{password}
 imap.Repository remote_%{id}.folderfilter ?~= %{imap_filter:-}
+imap.Repository remote_%{id}.remotepasseval ?= "mailpasswd(\"%{id}\")"
 # imap.Repository.remote_${id}.sslcacertfile = ...
 
 [accounts %{smtp_defaults:-}]

--- a/presets/defaults
+++ b/presets/defaults
@@ -147,4 +147,5 @@ smtp.tls_trust_file  ?~= "$(\
        "%{smtp.tls_certcheck:-}" == off ]] \
     || echo /etc/ssl/certs/ca-certificates.crt)"
 smtp.logfile          ?= ~/.msmtp/%{id}.log
+smtp.passwordeval     ?~= $(printn "gpg2 -q --for-your-eyes-only --no-tty -d ~/.keys/%{id}.asc")
 # smtp.maildomain ?= 


### PR DESCRIPTION
### Notes:
I added a ``lib/python_file.py`` which provides the decryption function for offlineimap. The file itself can also load a user-defined python file should the user create one in ``~/.offlineimap/userPython.py``. There are more details about this in the ``lib/python_file.py`` file itself.

### Needs fixing:
As of now, with these changes, each account **needs** to have a matching key as outlined below. What I couldn't figure out is how to implement a detection mechanism in ``presets/default`` that would go like:
- if account has a password, use it
- if not, add the necessary calls in both imap and smtp sections. Those
  calls being:
````
imap.Repository remote_%{id}.remotepasseval ?= "mailpasswd(\"%{id}\")"
````
and
````
smtp.passwordeval     ?~= $(printn "gpg2 -q --for-your-eyes-only --no-tty -d ~/.keys/%{id}.asc")
````
I know you have a similiar pattern already in the ``mutt.signature`` section, but didn't know exactly how this should look like.

### Prerequisites:
- ``.asc`` files with the passwords need to be stored as ``~/.offlineimap/keys/[account].asc`` ([reference](https://wiki.archlinux.org/index.php/GnuPG#Encrypt_and_decrypt) for how to generate a key)

- Each account that is to use gpg needs to have a matching to key (sans the file extension):
  ````
  [account samplehost]
  ````
  would require the password to be stored under ``~/.offlineimap/keys/samplehost.asc``

- Is is recommended to use a gpg agent so as not to have to input passwords on each sync
